### PR TITLE
Mac updates for GL Client

### DIFF
--- a/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
@@ -58,6 +58,8 @@ elseif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(plGLClient_SOURCES ${plGLClient_SOURCES}
         OSX/main.mm
     )
+    #we know OpenGL is deprecated, but silence the warnings for now
+    add_compile_definitions(GL_SILENCE_DEPRECATION)
 elseif(UNIX)
     set(plGLClient_SOURCES ${plGLClient_SOURCES}
         X11/main.cpp

--- a/Sources/Plasma/Apps/plGLClient/OSX/main.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/main.mm
@@ -55,6 +55,8 @@ void PumpMessageQueueProc();
 }
 
 @property (retain) NSTimer *drawTimer;
+@property const char **argv;
+@property int argc;
 
 @end
 
@@ -81,13 +83,13 @@ void PumpMessageQueueProc();
     // Window controller
     NSWindowController * windowController = [[[NSWindowController alloc] initWithWindow:window] autorelease];
 
-    gClient.SetClientWindow((hsWindowHndl)window);
-    gClient.SetClientDisplay((hsWindowHndl)NULL);
     [window setTitle:@"Uru"];
     [window setContentSize:NSMakeSize(800, 600)];
     [window orderFrontRegardless];
     
-    gClient.SetClientWindow((size_t *)window);
+    gClient.SetClientWindow((hsWindowHndl)window);
+    gClient.SetClientDisplay((hsWindowHndl)NULL);
+    gClient.Init(_argc, _argv);
     //NSApp.mainWindow = window;
     //[NSApp run];
     
@@ -174,8 +176,9 @@ int main(int argc, const char** argv)
     // 'NSApp' with the application instance.
         //[application setDelegate:delegate];
     
-    gClient.Init(argc, argv);
     AppDelegate *delegate = [AppDelegate new];
+    delegate.argv = argv;
+    delegate.argc = argc;
     
     NSMenu *mainMenu = [[NSMenu alloc] init];
     NSApplication * application = [NSApplication sharedApplication];

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -38,6 +38,11 @@ set(CoreLib_SOURCES
     hsWindows.cpp
 )
 
+# Other platforms may not be friendly to Obj-C mm files, only add them for Apple targets
+if(APPLE)
+    list(APPEND CoreLib_SOURCES hsMac.mm)
+endif(APPLE)
+
 if(WIN32 AND NOT CYGWIN)
     set(CoreLib_SOURCES ${CoreLib_SOURCES}
         hsThread_Win.cpp
@@ -75,6 +80,7 @@ set(CoreLib_HEADERS
     hsThread.h
     hsWide.h
     hsWindows.h
+    hsMac.hpp
     pcSmallRect.h
     plCmdParser.h
     plFileSystem.h

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -80,7 +80,7 @@ set(CoreLib_HEADERS
     hsThread.h
     hsWide.h
     hsWindows.h
-    hsMac.hpp
+    hsMac.h
     pcSmallRect.h
     plCmdParser.h
     plFileSystem.h

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -47,6 +47,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <crtdbg.h>
 #endif
 
+#if __APPLE__
+#include "hsMac.hpp"
+#endif
+
 #pragma hdrstop
 
 #if defined(HS_BUILD_FOR_UNIX)
@@ -350,7 +354,8 @@ int hsMessageBoxWithOwner(hsWindowHndl owner, const char* message, const char* c
     case IDNO:          return hsMBoxNo;
     default:            return hsMBoxCancel;
     }
-
+#elseif HS_BUILD_FOR_APPLE
+    hsMessageBoxWithOwnerMac(owner, message, caption, kind, icon);
 #endif
     return hsMBoxCancel;
 }
@@ -403,7 +408,9 @@ int hsMessageBoxWithOwner(hsWindowHndl owner, const wchar_t* message, const wcha
     case IDNO:          return hsMBoxNo;
     default:            return hsMBoxCancel;
     }
-
+    
+#elseif HS_BUILD_FOR_APPLE
+    hsMessageBoxWithOwnerMac(owner, message, caption, kind, icon);
 #endif
     return hsMBoxCancel;
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -47,8 +47,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <crtdbg.h>
 #endif
 
-#if __APPLE__
-#include "hsMac.hpp"
+#if HS_BUILD_FOR_APPLE
+#include "hsMac.h"
 #endif
 
 #pragma hdrstop

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -125,7 +125,7 @@ void ErrorEnableGui(bool enabled)
     s_GuiAsserts = enabled;
 }
 
-NORETURN void ErrorAssert(int line, const char* file, const char* fmt, ...)
+NORETURN_IF_NOT_MINIMAL_GL_BUILD void ErrorAssert(int line, const char* file, const char* fmt, ...)
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
     char msg[1024];

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -87,7 +87,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     typedef long HRESULT;
     typedef void* HANDLE;
 #else
-    typedef int32_t* hsWindowHndl;
+    typedef size_t* hsWindowHndl;
     typedef int32_t* hsWindowInst;
 #endif // HS_BUILD_FOR_WIN32
 
@@ -382,7 +382,13 @@ extern hsDebugMessageProc gHSStatusProc;
 hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
 
 void ErrorEnableGui (bool enabled);
-NORETURN void ErrorAssert (int line, const char* file, const char* fmt, ...);
+
+#ifndef MINIMAL_GL_BUILD
+#define NORETURN_IF_NOT_MINIMAL_GL_BUILD NORETURN
+#else
+#define NORETURN_IF_NOT_MINIMAL_GL_BUILD
+#endif
+NORETURN_IF_NOT_MINIMAL_GL_BUILD void ErrorAssert (int line, const char* file, const char* fmt, ...);
 
 bool DebugIsDebuggerPresent();
 void DebugBreakIfDebuggerPresent();

--- a/Sources/Plasma/CoreLib/hsMac.h
+++ b/Sources/Plasma/CoreLib/hsMac.h
@@ -40,8 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#ifndef HeadSpinMac_hpp
-#define HeadSpinMac_hpp
+#ifndef HeadSpinMac_h
+#define HeadSpinMac_h
 
 #if HS_BUILD_FOR_MACOS
 

--- a/Sources/Plasma/CoreLib/hsMac.hpp
+++ b/Sources/Plasma/CoreLib/hsMac.hpp
@@ -1,0 +1,55 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef HeadSpinMac_hpp
+#define HeadSpinMac_hpp
+
+#if HS_BUILD_FOR_MACOS
+
+#include "HeadSpin.h"
+
+#include <stdio.h>
+int hsMessageBoxWithOwnerMac(hsWindowHndl owner, const char* message, const char* caption, int kind, int icon);
+
+#endif
+
+#endif /* HeadSpinMac_hpp */

--- a/Sources/Plasma/CoreLib/hsMac.mm
+++ b/Sources/Plasma/CoreLib/hsMac.mm
@@ -1,0 +1,67 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#if HS_BUILD_FOR_MACOS
+
+#include <AppKit/AppKit.h>
+#include "hsMac.hpp"
+
+int hsMessageBoxWithOwnerMac(hsWindowHndl owner, const char* message, const char* caption, int kind, int icon)
+{
+    @autoreleasepool {
+        NSString *title = [NSString stringWithCString:(const char*)caption encoding:NSUTF8StringEncoding];
+        NSString *messageText = [NSString stringWithCString:(const char*)message encoding:NSUTF8StringEncoding];
+        /*
+         Message boxes are only allowed to be created from the main thread,
+         but if this function is called from the main thread we will deadlock.
+         This implementation works for now but needs more consideration in the future.
+         */
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            NSAlert *alert = [[NSAlert alloc] init];
+            alert.messageText = title;
+            alert.informativeText = messageText;
+            [alert runModal];
+        });
+    }
+}
+
+#endif

--- a/Sources/Plasma/CoreLib/hsMac.mm
+++ b/Sources/Plasma/CoreLib/hsMac.mm
@@ -43,7 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #if HS_BUILD_FOR_MACOS
 
 #include <AppKit/AppKit.h>
-#include "hsMac.hpp"
+#include "hsMac.h"
 
 int hsMessageBoxWithOwnerMac(hsWindowHndl owner, const char* message, const char* caption, int kind, int icon)
 {

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -41,7 +41,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "HeadSpin.h"
 #include <al.h>
+#if __APPLE__
+#include <OpenAL/OpenAL.h>
+#else
 #include <efx.h>
+#endif
 #ifdef EAX_SDK_AVAILABLE
 #include <eax.h>
 #endif

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem_Private.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem_Private.h
@@ -46,7 +46,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include <al.h>
 #include <alc.h>
+#if __APPLE__
+#include <OpenAL/OpenAL.h>
+#else
 #include <efx.h>
+#endif
 #ifdef EAX_SDK_AVAILABLE
 #include <eax.h>
 #endif

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/eglCocoa_helpers.c
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/eglCocoa_helpers.c
@@ -118,6 +118,12 @@ static void helperAddRendererConfigs(OSX_EGLDisplay* display, CGLRendererInfoObj
                         c.surface_type = 0;
                         PFINFO(kCGLPFASampleBuffers, c.sample_buffers);
                         PFINFO(kCGLPFASamples, c.samples);
+                        
+                        //macOS doesn't seem to want to report sample buffers or samples
+                        //this might be a request only property and not queryable?
+                        //For now just make up an answer. Needs to be revisited.
+                        c.sample_buffers = 1;
+                        c.samples = 4;
 
                         fprintf(stderr, "\t0x%02x: %dbpp (%d-%d-%d-%d) depth %-2d stencil %d GL %d\n",
                             c.id, c.buffer_bits, c.red_bits,

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -373,6 +373,23 @@ void plGLMaterialShaderRef::ISetShaderVariableLocs()
     glBindAttribLocation(fRef, kVtxUVWSrc12, "aVtxUVWSrc12");
 
     glLinkProgram(fRef);
+    
+#ifdef HS_DEBUGGING
+    {
+        GLint compiled = 0;
+        glGetProgramiv(fRef, GL_LINK_STATUS, &compiled);
+        if (compiled == 0) {
+            hsStatusMessage("Not linked Vtx");
+            GLint length = 0;
+            glGetProgramiv(fRef, GL_INFO_LOG_LENGTH, &length);
+            if (length) {
+                char* log = new char[length];
+                glGetProgramInfoLog(fRef, length, &length, log);
+                hsStatusMessage(log);
+            }
+        }
+    }
+#endif
 
 #ifdef HS_DEBUGGING
     GLenum e;

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plShaderNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plShaderNode.cpp
@@ -218,6 +218,7 @@ ST::string plShaderContext::Render()
     if (this->type == kFragment) {
         out << "precision mediump float;\n";
     }
+    out << "precision lowp int;\n";
 
     for (std::shared_ptr<plShaderStruct> st : this->structs) {
         out << ST::format("struct {} {{\n", st->name);


### PR DESCRIPTION
Essentials to get this up and running again on the Mac. Should build and run minimally now.

- Adds some Mac support to Headspin for dialogs
- macOS is picky about int precision in the geometry and vertex shaders, caused link error
- Fixes for OpenAL include
- Temporary fixes for pixel format checking. macOS won't report sample buffers or level, still not sure why.
- Starting to re-arrange the Mac main.m to build on NSApplication and a Cocoa event loop. This will let normal UI events pass through more cleanly.