### PR TITLE
More GL client Mac fixes

### DIFF
--- a/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
@@ -149,6 +149,11 @@ elseif(UNIX)
     target_link_libraries(plGLClient X11)
 endif()
 
+if(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    #enable automatic memory management for the Obj-C code
+    set_property (TARGET plGLClient APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
+endif()
+
 if(PLASMA_USE_OPUS)
     target_link_libraries(plGLClient ${Opus_LIBRARIES})
 endif()

--- a/Sources/Plasma/Apps/plGLClient/OSX/main.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/main.mm
@@ -84,16 +84,14 @@ PF_CONSOLE_LINK_ALL()
     // Window controller
     NSWindowController * windowController = [[[NSWindowController alloc] initWithWindow:window] autorelease];
 
-    [window setTitle:@"Uru"];
-    [window setContentSize:NSMakeSize(800, 600)];
-    [window orderFrontRegardless];
+    // Window controller
+    [self.window setContentSize:NSMakeSize(800, 600)];
+    [self.window orderFrontRegardless];
     
-    gClient.SetClientWindow((hsWindowHndl)window);
     PF_CONSOLE_INITIALIZE(Audio);
+    gClient.SetClientWindow((hsWindowHndl)(__bridge void *)self.window);
     gClient.SetClientDisplay((hsWindowHndl)NULL);
     gClient.Init(_argc, _argv);
-    //NSApp.mainWindow = window;
-    //[NSApp run];
     
     // We should quite frankly be done initing the client by now. But, if not, spawn the good old
     // "Starting URU, please wait..." dialog (not so yay)
@@ -102,18 +100,11 @@ PF_CONSOLE_LINK_ALL()
         [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate now]];
     }
     
+    [self.window setTitle:[NSString stringWithCString:plProduct::LongName().c_str() encoding:NSUTF8StringEncoding]];
+    
     if(!gClient) {
         exit(0);
     }
-
-    // Can't do this threaded on mac
-    if (gClient->InitPipeline(NULL) ||
-        !gClient->StartInit()) {
-        gClient->SetDone(true);
-    }
-
-    gClient->SetQuitIntro(true);
-
 
     // Main loop
     if (gClient && !gClient->GetDone())

--- a/Sources/Plasma/Apps/plGLClient/plClientLoader.cpp
+++ b/Sources/Plasma/Apps/plGLClient/plClientLoader.cpp
@@ -105,11 +105,9 @@ void plClientLoader::Run()
     }
 #endif
 
-#ifndef HS_BUILD_FOR_APPLE
     if (fClient->InitPipeline(fDisplay) || !fClient->StartInit()) {
         fClient->SetDone(true);
     }
-#endif
 
     HandleArguments();
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
@@ -558,7 +558,7 @@ EGLBoolean eglSwapBuffers(EGLDisplay dpy, EGLSurface surface_)
         return EGL_FALSE;
     }
 
-    glFlush();
+    //glFlush();
 
     CGLError err = CGLFlushDrawable(context->ctx);
     if(err != kCGLNoError) {

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -553,6 +553,7 @@ void plGLPipeline::RenderSpans(plDrawableSpans* ice, const hsTArray<int16_t>& vi
                                 material,
                                 tempIce.fVStartIdx, tempIce.fVLength,   // These are used as our accumulated range
                                 tempIce.fIPackedIdx, tempIce.fILength );
+            glDeleteVertexArrays(1, &vao);
         }
 
         // Restart our search...


### PR DESCRIPTION
- Fixes for eglCocoa and enabling of threaded setup
- Enabling ARC for Obj-C for automatic and more efficient memory management
- Fix for double OpenGL flush in eglCocoa
- Setting the window title to the product name instead of hardcoded Uru
- Fix for a memory leak with vertex array allocation
- Input is still coming, I'm working on getting it more orderly and complete