### PR TITLE
macOS/Cocoa Input

### DIFF
--- a/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
@@ -59,6 +59,10 @@ elseif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     include_directories("../../PubUtilLib/plPipeline/GL/OSX")
     set(plGLClient_SOURCES ${plGLClient_SOURCES}
         OSX/main.mm
+        OSX/PLSKeyboardEventMonitor.mm
+    )
+    set(plGLClient_HEADERS ${plGLClient_HEADERS}
+        OSX/PLSKeyboardEventMonitor.h
     )
     #we know OpenGL is deprecated, but silence the warnings for now
     add_compile_definitions(GL_SILENCE_DEPRECATION)

--- a/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
@@ -60,9 +60,11 @@ elseif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(plGLClient_SOURCES ${plGLClient_SOURCES}
         OSX/main.mm
         OSX/PLSKeyboardEventMonitor.mm
+        OSX/PLSView.mm
     )
     set(plGLClient_HEADERS ${plGLClient_HEADERS}
         OSX/PLSKeyboardEventMonitor.h
+        OSX/PLSView.h
     )
     #we know OpenGL is deprecated, but silence the warnings for now
     add_compile_definitions(GL_SILENCE_DEPRECATION)

--- a/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plGLClient/CMakeLists.txt
@@ -143,6 +143,7 @@ target_link_libraries(plGLClient pfSurface)
 # System Libs
 if(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     target_link_libraries(plGLClient "-framework Cocoa")
+    target_link_libraries(plGLClient "-framework QuartzCore")
 elseif(UNIX)
     target_link_libraries(plGLClient xcb)
     target_link_libraries(plGLClient xcb-xfixes)

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.h
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.h
@@ -1,9 +1,44 @@
-//
-//  PLSEventMonitor.h
-//  plGLClient
-//
-//  Created by Colin Cornaby on 12/24/20.
-//
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
 
 #import <Cocoa/Cocoa.h>
 #include "plProduct.h"

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.h
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.h
@@ -1,0 +1,22 @@
+//
+//  PLSEventMonitor.h
+//  plGLClient
+//
+//  Created by Colin Cornaby on 12/24/20.
+//
+
+#import <Cocoa/Cocoa.h>
+#include "plProduct.h"
+#include "plGLClient/plGLClient.h"
+#include "plGLClient/plClientLoader.h"
+#include "plInputCore/plInputManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PLSKeyboardEventMonitor : NSObject
+
+-(id)initWithView:(NSView *)view inputManager:(plInputManager*)inputManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
@@ -42,7 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #import "PLSKeyboardEventMonitor.h"
 #include "plMessage/plInputEventMsg.h"
-#import <Carbon/Carbon.h>
 
 @interface PLSKeyboardEventMonitor ()
 

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
@@ -1,9 +1,44 @@
-//
-//  PLSEventMonitor.m
-//  plGLClient
-//
-//  Created by Colin Cornaby on 12/24/20.
-//
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
 
 #import "PLSKeyboardEventMonitor.h"
 #include "plMessage/plInputEventMsg.h"

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
@@ -43,6 +43,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #import "PLSKeyboardEventMonitor.h"
 #include "plMessage/plInputEventMsg.h"
 
+/*
+ This class implements a Cocoa keyboard tap for Plasma.
+ 
+ IOKit isn't being used for raw keyboard input because it requires special privacy permission in macOS Catalina and higher. The Cocoa event stream is cumbersome, but doesn't require an event stream.
+ 
+ There should be an alternate implementation for macOS 11 that uses the Game Controller framework, which supports keyboards in Big Sur and higher. That input is more appropriate for a game, and would also work on an iPad version. That is not yet implemented.
+ */
+
 @interface PLSKeyboardEventMonitor ()
 
 @property (weak) NSView *view;
@@ -100,7 +108,10 @@ NSEventMaskFlagsChanged;
         return;
     }
     
-    const unsigned short KEYCODE_LINUX_TO_HID[0x7F] = {
+    //Cocoa keycodes use the ids from the original Mac.
+    //Note that Cocoa will not return keycodes for modifier keys like shift.
+    //We have to check the modifier flags for that.
+    const unsigned short KEYCODE_MAC_TO_HID[0x7F] = {
          4, 22,  7,  9, 11, 10, 29, 27, 06, 25, 00, 05, 20, 26,  8, 21,
         //0x10
         28, 23, 30, 31, 32, 33, 35, 34, 46, 38, 36, 45, 37, 39, 48, 18,
@@ -125,7 +136,7 @@ NSEventMaskFlagsChanged;
     BOOL down = event.type == NSEventTypeKeyDown;
     
     unsigned short keycode = [event keyCode];
-    plKeyDef convertedKey = (plKeyDef)KEYCODE_LINUX_TO_HID[keycode];
+    plKeyDef convertedKey = (plKeyDef)KEYCODE_MAC_TO_HID[keycode];
     
     NSEventModifierFlags modifierFlags = [event modifierFlags];
     //if it's a shift key event only way to derive up or down is through presence in the modifier flag

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSKeyboardEventMonitor.mm
@@ -1,0 +1,111 @@
+//
+//  PLSEventMonitor.m
+//  plGLClient
+//
+//  Created by Colin Cornaby on 12/24/20.
+//
+
+#import "PLSKeyboardEventMonitor.h"
+#include "plMessage/plInputEventMsg.h"
+#import <Carbon/Carbon.h>
+
+@interface PLSKeyboardEventMonitor ()
+
+@property (weak) NSView *view;
+@property plInputManager *inputManager;
+@property (retain) id localMonitor;
+
+@end
+
+@implementation PLSKeyboardEventMonitor
+
+NSEventMask eventMasks =
+NSEventMaskKeyDown |
+NSEventMaskKeyUp |
+NSEventMaskFlagsChanged;
+
+-(id)initWithView:(NSView *)view inputManager:(plInputManager*)inputManager
+{
+    self = [super init];
+    self.view = view;
+    self.inputManager = inputManager;
+    
+    self.localMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:eventMasks handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
+        if([self processEvent:event]) {
+            return nil;
+        }
+        return event;
+    }];
+    
+    return self;
+}
+
+-(BOOL)processEvent:(NSEvent *)event {
+    //is this even an event for our window
+    if([event window] == [self.view window]) {
+        switch(event.type) {
+            case NSEventTypeKeyDown:
+            case NSEventTypeKeyUp:
+            case NSEventTypeFlagsChanged: {
+                [self processKeyEvent:event];
+                break;
+            }
+            default:
+                NSLog(@"Unexpected unhandled event type %@", event);
+                return NO;
+        }
+        if(event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+-(void)processKeyEvent:(NSEvent *)event {
+    if(event.type == NSEventTypeKeyDown && event.ARepeat) {
+        return;
+    }
+    
+    const unsigned short KEYCODE_LINUX_TO_HID[0x7F] = {
+         4, 22,  7,  9, 11, 10, 29, 27, 06, 25, 00, 05, 20, 26,  8, 21,
+        //0x10
+        28, 23, 30, 31, 32, 33, 35, 34, 46, 38, 36, 45, 37, 39, 48, 18,
+        //0x20
+        24, 47, 12, 19,158, 15, 13, 52, 14, 51, 49, 54, 56, 17, 16, 55,
+        //0x30
+        43, 44, 53, 42, 41, 0, 0, 0, 225, 57, 226,
+        //0x3B
+        224, 0, 0, 0, 0,
+        //0x40
+        00, 99, 00, 85, 00, 87, 00, 00, 00, 00, 00, 84, 158, 0, 86, 00,
+        //0x50
+        00, 00, 98, 89, 90, 91, 92, 93, 94, 95, 00, 96, 97,
+        //0x5D
+        0, 0, 0,
+        //0x60
+        62, 63, 64, 60, 65, 66, 00, 68, 00, 00, 00, 00, 00, 67, 00, 69,
+        //0x70
+        00, 00, 00, 74, 75, 76, 61, 77, 59, 78, 58, 80, 79, 81, 82
+    };
+    
+    BOOL down = event.type == NSEventTypeKeyDown;
+    
+    unsigned short keycode = [event keyCode];
+    plKeyDef convertedKey = (plKeyDef)KEYCODE_LINUX_TO_HID[keycode];
+    
+    NSEventModifierFlags modifierFlags = [event modifierFlags];
+    //if it's a shift key event only way to derive up or down is through presence in the modifier flag
+    if(convertedKey == KEY_SHIFT) {
+        down = (event.modifierFlags & NSEventModifierFlagShift) != 0;
+    }
+    if(convertedKey == KEY_ALT) {
+        down = (event.modifierFlags & NSEventModifierFlagOption) != 0;
+    }
+    if(convertedKey == KEY_CTRL) {
+        down = (event.modifierFlags & NSEventModifierFlagControl) != 0;
+    }
+    //NSLog(@"Key event %@, Plasma key is %i, is down %i", event, convertedKey, down);
+    self.inputManager->HandleKeyEvent(convertedKey, down, false);
+}
+
+@end

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSView.h
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSView.h
@@ -1,9 +1,44 @@
-//
-//  PLSView.h
-//  plGLClient
-//
-//  Created by Colin Cornaby on 12/27/20.
-//
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
 
 #import <Cocoa/Cocoa.h>
 #include "plInputCore/plInputManager.h"

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSView.h
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSView.h
@@ -1,0 +1,19 @@
+//
+//  PLSView.h
+//  plGLClient
+//
+//  Created by Colin Cornaby on 12/27/20.
+//
+
+#import <Cocoa/Cocoa.h>
+#include "plInputCore/plInputManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PLSView : NSView
+
+@property plInputManager * inputManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
@@ -43,6 +43,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #import "PLSView.h"
 #include "plMessage/plInputEventMsg.h"
 
+/*
+ Plasma view for Cocoa
+ 
+ This view doesn't interact with drawing yet. Ideally it should implement an OpenGL layer and use the still-deprecated-but-more-supported fully hardware accelerated path. Right now it's allowing the OpenGL context to drive it as a dumb view.
+ 
+ Mouse input is handled here. The raw event stream is too wide for good mouse support, and sends events for a lot of unrelated views like the menu bar or window chrome. Using a view in the responder chain will automatically filter down to just our events.
+ 
+ Game Controller in Big Sur also implements mouse support. Becuase Plasma uses a cursor, Cocoa mouse support might be adequate.
+ */
+
 @interface PLSView ()
 
 @property NSTrackingArea *mouseTrackingArea;
@@ -51,6 +61,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 @implementation PLSView
 
+//MARK: View setup
 -(id)initWithFrame:(NSRect)frameRect
 {
     self = [super initWithFrame:frameRect];
@@ -71,6 +82,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [super drawRect:dirtyRect];
 }
 
+
+//MARK: Left mouse button
 -(void)mouseDown:(NSEvent *)event
 {
     [self handleMouseButtonEvent:event];
@@ -86,6 +99,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [self updateClientMouseLocation:event];
 }
 
+//MARK: Right mouse button
 -(void)rightMouseDown:(NSEvent *)event
 {
     [self handleMouseButtonEvent:event];
@@ -101,6 +115,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [self updateClientMouseLocation:event];
 }
 
+//MARK: Mouse movement
 -(void)mouseMoved:(NSEvent *)event {
     [self updateClientMouseLocation:event];
 }
@@ -116,6 +131,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [NSCursor unhide];
 }
 
+//MARK: Cocoa region tracking
 -(void)updateTrackingAreas
 {
     if(self.mouseTrackingArea) {
@@ -125,6 +141,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [self addTrackingArea:self.mouseTrackingArea];
 }
 
+//MARK: Mouse click handler
 -(void)handleMouseButtonEvent:(NSEvent *)event {
     [self updateClientMouseLocation:event];
     

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
@@ -1,0 +1,143 @@
+//
+//  PLSView.m
+//  plGLClient
+//
+//  Created by Colin Cornaby on 12/27/20.
+//
+
+#import "PLSView.h"
+#include "plMessage/plInputEventMsg.h"
+
+@interface PLSView ()
+
+@property NSTrackingArea *mouseTrackingArea;
+
+@end
+
+@implementation PLSView
+
+-(id)initWithFrame:(NSRect)frameRect
+{
+    self = [super initWithFrame:frameRect];
+    return self;
+}
+
+- (BOOL)acceptsFirstResponder
+{
+    return YES;
+}
+
+- (BOOL)wantsLayer
+{
+    return YES;
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+    [super drawRect:dirtyRect];
+}
+
+-(void)mouseDown:(NSEvent *)event
+{
+    [self handleMouseButtonEvent:event];
+}
+
+-(void)mouseUp:(NSEvent *)event
+{
+    [self handleMouseButtonEvent:event];
+}
+
+-(void)mouseDragged:(NSEvent *)event
+{
+    [self updateClientMouseLocation:event];
+}
+
+-(void)rightMouseDown:(NSEvent *)event
+{
+    [self handleMouseButtonEvent:event];
+}
+
+-(void)rightMouseUp:(NSEvent *)event
+{
+    [self handleMouseButtonEvent:event];
+}
+
+-(void)rightMouseDragged:(NSEvent *)event
+{
+    [self updateClientMouseLocation:event];
+}
+
+-(void)mouseMoved:(NSEvent *)event {
+    [self updateClientMouseLocation:event];
+}
+
+-(void)mouseEntered:(NSEvent *)event
+{
+    [NSCursor hide];
+}
+
+-(void)mouseExited:(NSEvent *)event
+{
+    //[super mouseExited:event];
+    [NSCursor unhide];
+}
+
+-(void)updateTrackingAreas
+{
+    if(self.mouseTrackingArea) {
+        [self removeTrackingArea:self.mouseTrackingArea];
+    }
+    self.mouseTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:NSTrackingMouseEnteredAndExited | NSTrackingActiveWhenFirstResponder owner:self userInfo:nil];
+    [self addTrackingArea:self.mouseTrackingArea];
+}
+
+-(void)handleMouseButtonEvent:(NSEvent *)event {
+    [self updateClientMouseLocation:event];
+    
+    CGPoint windowLocation = [event locationInWindow];
+    CGPoint viewLocation = [self convertPoint:windowLocation fromView:nil];
+    
+    plIMouseBEventMsg* pBMsg = new plIMouseBEventMsg;
+    
+    if(event.type == NSEventTypeLeftMouseUp) {
+        pBMsg->fButton |= kLeftButtonUp;
+    }
+    else if(event.type == NSEventTypeRightMouseUp) {
+        pBMsg->fButton |= kRightButtonUp;
+    }
+    else if(event.type == NSEventTypeLeftMouseDown) {
+        pBMsg->fButton |= kLeftButtonDown;
+    }
+    else if(event.type == NSEventTypeRightMouseDown) {
+        pBMsg->fButton |= kRightButtonDown;
+    }
+    
+    self.inputManager->MsgReceive(pBMsg);
+    
+    delete(pBMsg);
+}
+
+-(void)updateClientMouseLocation:(NSEvent *)event {
+    CGPoint windowLocation = [event locationInWindow];
+    CGPoint viewLocation = [self convertPoint:windowLocation fromView:nil];
+    
+    NSRect windowViewBounds = self.bounds;
+    CGFloat deltaX = (windowLocation.x) / windowViewBounds.size.width;
+    CGFloat deltaY = (windowViewBounds.size.height - windowLocation.y) / windowViewBounds.size.height;
+    
+    plIMouseXEventMsg* pXMsg = new plIMouseXEventMsg;
+    plIMouseYEventMsg* pYMsg = new plIMouseYEventMsg;
+    
+    pXMsg->fWx = viewLocation.x;
+    pXMsg->fX = deltaX;
+
+    pYMsg->fWy = (windowViewBounds.size.height - windowLocation.y);
+    pYMsg->fY = deltaY;
+    
+    self.inputManager->MsgReceive(pXMsg);
+    self.inputManager->MsgReceive(pYMsg);
+    
+    delete(pXMsg);
+    delete(pYMsg);
+}
+
+@end

--- a/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/PLSView.mm
@@ -1,9 +1,44 @@
-//
-//  PLSView.m
-//  plGLClient
-//
-//  Created by Colin Cornaby on 12/27/20.
-//
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
 
 #import "PLSView.h"
 #include "plMessage/plInputEventMsg.h"

--- a/Sources/Plasma/Apps/plGLClient/OSX/main.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/main.mm
@@ -132,27 +132,31 @@ PF_CONSOLE_LINK_ALL()
 
 void PumpMessageQueueProc()
 {
-    NSEvent* event;
-
-    while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                            untilDate:[NSDate distantPast]
-                            inMode:NSDefaultRunLoopMode
-                            dequeue:YES]) != nil)
-    {
-
-        switch ([event type])
+    /*
+     Normally we want to receive events from the normal app event loop,
+     but the intro movie blocks the normal event loop. This lets us
+     manually process key down during the intro.
+     */
+    plClientLoader &gClient = ((AppDelegate *)[NSApp delegate])->gClient;
+    if(gClient->GetQuitIntro() == false) {
+        NSEvent *event;
+        [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate now]];
+        while ((event = [NSApp nextEventMatchingMask:NSEventMaskKeyDown
+                                    untilDate:[NSDate distantPast]
+                                    inMode:NSDefaultRunLoopMode
+                                    dequeue:YES]) != nil)
         {
-        case NSEventTypeKeyDown:
+            switch ([event type])
             {
-                gClient->SetDone(true);
+            case NSEventTypeKeyDown:
+                {
+                    gClient->SetQuitIntro(true);
+                }
+                break;
+            default:
+                break;
             }
-            break;
-        default:
-            break;
         }
-
-        [NSApp sendEvent:event];
-        [NSApp updateWindows];
     }
 }
 

--- a/Sources/Plasma/Apps/plGLClient/OSX/main.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/main.mm
@@ -53,6 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #import <OpenGL/gl.h>
 #import <QuartzCore/QuartzCore.h>
 #import "PLSKeyboardEventMonitor.h"
+#import "PLSView.h"
 
 
 void PumpMessageQueueProc();
@@ -87,6 +88,7 @@ PF_CONSOLE_LINK_ALL()
                         styleMask:windowStyle
                         backing:NSBackingStoreBuffered
                         defer:NO];
+    window.contentView = [[PLSView alloc] init];
     
     self = [super initWithWindow:window];
     self.window.acceptsMouseMovedEvents = YES;
@@ -120,6 +122,7 @@ PF_CONSOLE_LINK_ALL()
     }
     
     self.eventMonitor = [[PLSKeyboardEventMonitor alloc] initWithView:self.window.contentView inputManager:gClient->GetInputManager()];
+    ((PLSView *)self.window.contentView).inputManager = gClient->GetInputManager();
 
     // Main loop
     if (gClient && !gClient->GetDone())

--- a/Sources/Plasma/Apps/plGLClient/OSX/main.mm
+++ b/Sources/Plasma/Apps/plGLClient/OSX/main.mm
@@ -83,10 +83,10 @@ PF_CONSOLE_LINK_ALL()
     // Window bounds (x, y, width, height)
     NSRect windowRect = NSMakeRect(100, 100, 800, 600);
 
-    NSWindow * window = [[[NSWindow alloc] initWithContentRect:windowRect
+    NSWindow * window = [[NSWindow alloc] initWithContentRect:windowRect
                         styleMask:windowStyle
                         backing:NSBackingStoreBuffered
-                        defer:NO] autorelease];
+                        defer:NO];
 
     // Window controller
     NSWindowController * windowController = [[[NSWindowController alloc] initWithWindow:window] autorelease];

--- a/Sources/Plasma/Apps/plGLClient/plClientLoader.h
+++ b/Sources/Plasma/Apps/plGLClient/plClientLoader.h
@@ -40,6 +40,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#ifndef plClientLoader_h
+#define plClientLoader_h
+
 #include "HeadSpin.h"
 #include "hsThread.h"
 #include "plCmdParser.h"
@@ -116,4 +119,5 @@ public:
     operator bool() const { return fClient != nullptr; }
 };
 
+#endif
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
@@ -419,6 +419,7 @@ EGLContext eglCreateContext(EGLDisplay dpy, EGLConfig config_, EGLContext share_
         //deglSetError(EGL_BAD_ALLOC);
         return EGL_NO_CONTEXT;
     }
+    CGLEnable( context->ctx, kCGLCEMPEngine);
 
     CGLRetainContext(context->ctx);
     context->nsctx = NULL;


### PR DESCRIPTION
Input mechanisms for Cocoa:

- Cocoa wants Cocoa classes to use a three letter prefix in since namespaces aren't supported. I picked PLS for Cocoa classes.
- Keyboard is implemented as a raw event trap. Cocoa keyboard events are tricky because they use the same key codes from the original Mac OS. They also don't report modifier keys like shift. macOS 11 has a more modern Game Controller framework with keyboard input that is probably a lot more analogous to Windows and Linux. I haven't implemented that as an alternative, but it's on my list of things to do.
- Mouse support is also tricky. I was able to address a lot of problems by avoiding the raw event stream, and implementing a Plasma view. Cocoa will automatically filter down mouse events to whatever is related to the view, instead of the mouse events for unrelated things like window chrome and menu items.
- IOKit is the macOS device driver API, and can also be used to tap keyboard and mouse events. But it requires special user authorization. The Big Sur Game Controller API seems like the way forward, and that also works on iPad.
- There are a few other changes. I turned on multithreaded OpenGL, so flushing will do it's work on a secondary thread. Takes a bit more time off the main thread.
- Also switched the draw loop to use CVDisplayLink. This will provide capabilities like vsync and not exceeding the frame rate of the display.