### PR TITLE
Fix GPU selection + render fails on macOS

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/egl_api.c
@@ -59,25 +59,7 @@ EGLBoolean eglInitialize(EGLDisplay dpy, EGLint *major, EGLint *minor)
         CGLGetVersion(&display->major, &display->minor);
 
         if (!display->cocoa_config) {
-            CGLRendererInfoObj renderers;
-            GLint nrend = 0;
-            CGLError err = CGLQueryRendererInfo(CGDisplayIDToOpenGLDisplayMask(display->id), &renderers, &nrend);
-            display->config_count = 0;
-
-            if (err == kCGLNoError) {
-                GLint i = 0;
-
-                fprintf(stderr, "available renderers:\n");
-                for(; i < nrend; i++)
-                {
-                    helperAddRendererConfigs(display, renderers, i);
-                }
-                CGLDestroyRendererInfo(renderers);
-            }
-            else
-            {
-                fprintf(stderr, "CGLQueryRendererInfo failed: %s\n", CGLErrorString(err));
-            }
+            helperAddRendererConfigs(display);
         }
 
         display->initialized = 1;
@@ -411,7 +393,8 @@ EGLContext eglCreateContext(EGLDisplay dpy, EGLConfig config_, EGLContext share_
     }
     fprintf(stderr, "Context version %d creation requested.\n", context->version);
 
-    CGLError err = CGLCreateContext(((OSX_EGLConfig*)config_)->pf, share_context ? share_context->ctx : NULL, &context->ctx);
+    CGLPixelFormatObj pf = ((OSX_EGLConfig*)config_)->pf;
+    CGLError err = CGLCreateContext(pf, share_context ? share_context->ctx : NULL, &context->ctx);
     if(err != kCGLNoError)
     {
         fprintf(stderr, "CGLCreateContext failed: %s\n", CGLErrorString(err));


### PR DESCRIPTION
Happy new year! Long Git description follows... Plasma was not running on my dual GPU MacBook Pro, this is a fix.

The way eglCocoa selects GPUs causes problems on modern Macs. I found Plasma would simply not render on my Macbook Pro with an Iris Pro  + Radeon 560. These changes allows Apple’s OpenGL implementation to pick the right renderer and display mode. We’ll ask for the correct display mode, and OpenGL will offer us one back. The egl interface is still the same, only on the Mac there will only be one mode to pick from. We can consider multiple render devices later, but letting the system pick the best render device itself is worth unbreaking some Macs.

Background:
On a lot of Macs, there is both a low power GPU and a high power GPU. The high power GPU will be left inactive and unattached from the display until it is needed. We want Plasma to ask for the high powered GPU. On dual GPU systems, we may even be blocked from using the integrated GPU becsause it requires us to opt into a low/high power dynamic switching mode that we don’t currently support.

On dual GPU Macbook Pros this code would look at the renderers currently attached/available for the display. It would find the integrated GPU, which we aren’t allowed to use  on dual GPU systems without the special mode support. The high end GPU would never be attached to the display because we only asked to talk to GPUs presently attached to the display. And Plasma would fall back on the software(!!!) renderer because it was the only renderer compatible with what we wanted, available for the display.

To fix this, we just need to ask for a GL display mode without asking for a specific device. macOS will automatically spin up the proper device for the display mode, including the high performance GPU. There might be value in having a GPU selector in the future, but I’m just going to let macOS do the right thing for now. There also might be more work to do for multi GPU systems with multiple monitors and moving Plasma between displays/cards.

This will also fix situations like eGPUs where an eGPU might be the desired render target but is never actually attached to a display. The user can set the eGPU as the desired render target in their system settings. When we allow macOS to assign us to whatever render target it wants , it will pin us to the eGPU.