### PR TITLE
Forgot to clear stencil bits, causes errors on release builds

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/eglCocoa_helpers.c
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/OSX/eglCocoa_helpers.c
@@ -67,6 +67,7 @@ static void helperAddRendererConfigs(OSX_EGLDisplay* display)
     c.alpha_bits = 8;
     c.depth_bits = 16;
     c.buffer_bits = 32;
+    c.stencil_bits = 0;
     CGLPixelFormatAttribute attribs[64], i = 0;
     attribs[i++] = kCGLPFAClosestPolicy;
     attribs[i++] = kCGLPFAAccelerated;


### PR DESCRIPTION
Stencil bits is usually garbage, which causes us to tell Core GL we need a really high stencil bits value, which causes us to fail to find a pixel format on release builds.