### PR TITLE
Use PBOs for texture loading

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.cpp
@@ -191,6 +191,7 @@ bool plGLDevice::InitDevice()
     glEnable(GL_MULTISAMPLE);
     glFrontFace(GL_CCW);
     glCullFace(GL_BACK);
+    glGenBuffers(1, &fTextureLoadPBO);
 
     return true;
 }
@@ -602,7 +603,7 @@ void plGLDevice::BindTexture(TextureRef* tRef, plMipmap* img, GLuint mapping)
         for (GLuint lvl = 0; lvl <= tRef->fLevels; lvl++) {
             img->SetCurrLevel(lvl);
             
-            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, fTextureLoadPBO);
             glBufferData(GL_PIXEL_UNPACK_BUFFER, img->GetCurrLevelSize(), NULL, GL_STATIC_DRAW);
             
             void* imgBuffer = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
@@ -616,7 +617,6 @@ void plGLDevice::BindTexture(TextureRef* tRef, plMipmap* img, GLuint mapping)
             glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
         }
     }
-    glDeleteBuffers(1, &pbo);
 }
 
 void plGLDevice::MakeTextureRef(TextureRef* tRef, plLayerInterface* layer, plMipmap* img)

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.cpp
@@ -570,9 +570,6 @@ void plGLDevice::CheckTexture(TextureRef* tRef)
 void plGLDevice::BindTexture(TextureRef* tRef, plMipmap* img, GLuint mapping)
 {
     tRef->fLevels = img->GetNumLevels() - 1;
-    
-    GLuint pbo;
-    glGenBuffers(1, &pbo);
 
     if (img->IsCompressed()) {
         // Hack around the smallest levels being unusable
@@ -586,7 +583,7 @@ void plGLDevice::BindTexture(TextureRef* tRef, plMipmap* img, GLuint mapping)
         for (GLuint lvl = 0; lvl <= tRef->fLevels; lvl++) {
             img->SetCurrLevel(lvl);
             
-            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, fTextureLoadPBO);
             glBufferData(GL_PIXEL_UNPACK_BUFFER, img->GetCurrLevelSize(), NULL, GL_STATIC_DRAW);
             
             void* imgBuffer = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.h
@@ -85,6 +85,8 @@ public:
     GLfloat             fMatrixW2C[16];
     GLfloat             fMatrixC2W[16];
     GLfloat             fMatrixProj[16];
+    
+    GLuint              fTextureLoadPBO;
 
 public:
     plGLDevice();


### PR DESCRIPTION
This is a draft because while the performance *feels* better to me, the profiler tool disagrees. So I don't know if it's my own bias. The profiler tool actually says that performance may be very very slightly worse in some key frames. Thought maybe you could take a look and tell me what you thought. This difference to me feels most pronounced in ages like Teledahn.

The PBO is supposed to let texture loading become asynchronous, and only block if we actually need the texture. In theory it should help with the heavy texture loads we do while the engine is running. In theory we could use multiple PBOs and load textures in a multithreaded way, but I don't know if Plasma's textures are really large enough to justify that.

There also might be a gain if we could use the PBO's buffer directly for loading image data into, instead of doing a memcpy. I don't know enough about Plasma to know if that's a reasonable change to make. In theory, even with the copy, this should start reusing buffers as textures make their way to the GPU.

These PBOs are not configured to be updated after the initial texture load, but if there are any streaming textures, this sort of setup could be helpful.

This came out of some research I was doing into the DirectX renderer trying to figure out how they handled texture streaming. I don't think DirectX has PBOs, but it manages texture data in it's own way that is kind of similar. PBOs are also similar to how Metal optimizes texture loading.