### PR TITLE
Performance improvements for GL pipeline

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -84,6 +84,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plSurface/hsGMaterial.h"
 #include "plSurface/plLayer.h"
 
+#include "plGLight/plShadowSlave.h"
+#include "plGLight/plShadowCaster.h"
+
 
 #include "hsGMatState.inl"
 
@@ -489,7 +492,7 @@ bool plGLPipeline::EndRender() {
     if (--fInSceneDepth == 0) {
         retVal = fDevice.EndRender();
 
-        //IClearShadowSlaves();
+        IClearShadowSlaves();
     }
 
     // Do this last, after we've drawn everything
@@ -1572,7 +1575,18 @@ void plGLPipeline::IPreprocessAvatarTextures()
     fClothingOutfits.Swap(fPrevClothingOutfits);
 }
 
-
+// IClearShadowSlaves ///////////////////////////////////////////////////////////////////////////
+// At EndRender(), we need to clear our list of shadow slaves. They are only valid for one frame.
+void plGLPipeline::IClearShadowSlaves()
+{
+    int i;
+    for( i = 0; i < fShadows.GetCount(); i++ )
+    {
+        const plShadowCaster* caster = fShadows[i]->fCaster;
+        caster->GetKey()->UnRefObject();
+    }
+    fShadows.SetCount(0);
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
@@ -125,6 +125,8 @@ protected:
     void IEnableLight(plGLMaterialShaderRef* mRef, size_t i, plLightInfo* light);
     void IDisableLight(plGLMaterialShaderRef* mRef, size_t i);
     void IScaleLight(plGLMaterialShaderRef* mRef, size_t i, float scale);
+    
+    void IClearShadowSlaves();
 
     void IDrawPlate(plPlate* plate);
     void IPreprocessAvatarTextures();


### PR DESCRIPTION
Adds shadow child node cleanup to the end of a render pass.

pl3DPipeline is preparing shadow child nodes for objects in a scene even if they're not being rendered. At the end of rendering, the pipeline implementation is responsible for cleaning them up during EndRender(). Otherwise the nodes will pile up and make node traversal and adding extremely expensive as part of lighting computation.

I copied over the IClearShadowSlaves() from the DX version that gets run at EndRender() in that pipeline.

This was having a pretty significant affect on framerate. In Teledahn I was seeing 10 fps after going to outside the tree with 100% CPU usage on a release build. With this change I'm seeing 60 fps with 20-30% CPU usage on a release build. It's a fairly significant improvement that makes the client feel really smooth on my machine, whereas before it felt choppy.

I'm assuming a similar CPU improvement should be seen on Linux.