### PR TITLE
Fixes for cull mode in GL

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -1573,24 +1573,13 @@ void plGLPipeline::IPreprocessAvatarTextures()
     fClothingOutfits.Swap(fPrevClothingOutfits);
 }
 
-
-
-//// IIsViewLeftHanded ////////////////////////////////////////////////////////
-//  Returns true if the combination of the local2world and world2camera
-//  matrices is left-handed.
-
-bool plGLPipeline::IIsViewLeftHanded()
-{
-    return fView.GetViewTransform().GetOrthogonal() ^ ( fView.fLocalToWorldLeftHanded ^ fView.fWorldToCamLeftHanded ) ? true : false;
-}
-
 //// ISetCullMode /////////////////////////////////////////////////////////////
 //  Tests and sets the current winding order cull mode (CW, CCW, or none).
 // Will reverse the cull mode as necessary for left handed camera or local to world
 // transforms.
 void plGLPipeline::ISetCullMode(bool flip)
 {
-    if( IIsViewLeftHanded() ) {
+    if( fView.IIsViewLeftHanded() ) {
         glCullFace(GL_BACK);
     } else {
         glCullFace(GL_FRONT);

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -922,6 +922,7 @@ void plGLPipeline::IRenderBufferSpan(const plIcicle& span, hsGDeviceRef* vb,
             glDisable(GL_CULL_FACE);
         } else {
             glEnable(GL_CULL_FACE);
+            ISetCullMode();
         }
 
         // TEMP
@@ -1573,6 +1574,28 @@ void plGLPipeline::IPreprocessAvatarTextures()
 }
 
 
+
+//// IIsViewLeftHanded ////////////////////////////////////////////////////////
+//  Returns true if the combination of the local2world and world2camera
+//  matrices is left-handed.
+
+bool plGLPipeline::IIsViewLeftHanded()
+{
+    return fView.GetViewTransform().GetOrthogonal() ^ ( fView.fLocalToWorldLeftHanded ^ fView.fWorldToCamLeftHanded ) ? true : false;
+}
+
+//// ISetCullMode /////////////////////////////////////////////////////////////
+//  Tests and sets the current winding order cull mode (CW, CCW, or none).
+// Will reverse the cull mode as necessary for left handed camera or local to world
+// transforms.
+void plGLPipeline::ISetCullMode(bool flip)
+{
+    if( IIsViewLeftHanded() ) {
+        glCullFace(GL_BACK);
+    } else {
+        glCullFace(GL_FRONT);
+    }
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
@@ -128,6 +128,9 @@ protected:
 
     void IDrawPlate(plPlate* plate);
     void IPreprocessAvatarTextures();
+    
+    bool IIsViewLeftHanded();
+    void ISetCullMode(bool flip = false);
 };
 
 #endif // _plGLPipeline_inc_

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.h
@@ -129,7 +129,6 @@ protected:
     void IDrawPlate(plPlate* plate);
     void IPreprocessAvatarTextures();
     
-    bool IIsViewLeftHanded();
     void ISetCullMode(bool flip = false);
 };
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPipelineViewSettings.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPipelineViewSettings.cpp
@@ -414,3 +414,8 @@ bool plPipelineViewSettings::TestVisibleWorld(const plSceneObject* sObj)
     }
     return false;
 }
+
+bool plPipelineViewSettings::IIsViewLeftHanded()
+{
+    return GetViewTransform().GetOrthogonal() ^ ( fLocalToWorldLeftHanded ^ fWorldToCamLeftHanded ) ? true : false;
+}

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPipelineViewSettings.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPipelineViewSettings.h
@@ -236,6 +236,13 @@ public:
      * frustum.
      */
     bool    TestVisibleWorld(const plSceneObject* sObj);
+    
+    
+    /**
+     * Returns true if the combination of the local2world and world2camera
+     * matrices is left-handed.
+     */
+    bool    IIsViewLeftHanded();
 };
 
 


### PR DESCRIPTION
Adding support for both front face and back face culling. Plasma mixes both.

Ported this over from the DX/Metal clients. Should fix some missing rendering like the glow around the lights in the Writers Guild. May offer a small performance improvement.