### PR TITLE
Gl z fighting fixes

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -788,7 +788,7 @@ uint32_t plGLMaterialShaderRef::IHandleMaterial(uint32_t layer, std::shared_ptr<
     // Handle High Alpha Threshold
     std::shared_ptr<plUniformNode> alphaThreshold = IFindVariable<plUniformNode>("uAlphaThreshold", "float");
 
-    std::shared_ptr<plConditionNode> alphaTest = COND(IS_LESS(sb.fCurrAlpha, alphaThreshold));
+    std::shared_ptr<plConditionNode> alphaTest = COND(IS_LEQ(sb.fCurrAlpha, alphaThreshold));
     alphaTest->PushOp(CONSTANT("discard"));
 
     // if (final.a < alphaThreshold) { discard; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -685,6 +685,16 @@ uint32_t plGLMaterialShaderRef::IHandleMaterial(uint32_t layer, std::shared_ptr<
     // Ignoring the bit about self-rendering cube maps
 
     plLayerInterface* currLay = /*IPushOverBaseLayer*/ fMaterial->GetLayer(layer);
+    
+    /*
+     If the layer opacity is 0, don't draw it. This prevents it from contributing to the Z buffer.
+     This can happen with some models like the fire marbles in the neighborhood that have some models
+     for physics only, and then can block other rendering in the Z buffer.
+     DX pipeline does this in ILoopOverLayers.
+     */
+    if(currLay->GetOpacity() <= 0) {
+        return -1;
+    }
 
     if (fPipeline->IsDebugFlagSet(plPipeDbg::kFlagBumpW) && (currLay->GetMiscFlags() & hsGMatState::kMiscBumpDu)) {
         currLay = fMaterial->GetLayer(++layer);

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -685,16 +685,6 @@ uint32_t plGLMaterialShaderRef::IHandleMaterial(uint32_t layer, std::shared_ptr<
     // Ignoring the bit about self-rendering cube maps
 
     plLayerInterface* currLay = /*IPushOverBaseLayer*/ fMaterial->GetLayer(layer);
-    
-    /*
-     If the layer opacity is 0, don't draw it. This prevents it from contributing to the Z buffer.
-     This can happen with some models like the fire marbles in the neighborhood that have some models
-     for physics only, and then can block other rendering in the Z buffer.
-     DX pipeline does this in ILoopOverLayers.
-     */
-    if(currLay->GetOpacity() <= 0) {
-        return -1;
-    }
 
     if (fPipeline->IsDebugFlagSet(plPipeDbg::kFlagBumpW) && (currLay->GetMiscFlags() & hsGMatState::kMiscBumpDu)) {
         currLay = fMaterial->GetLayer(++layer);

--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -887,6 +887,16 @@ void plGLPipeline::IRenderBufferSpan(const plIcicle& span, hsGDeviceRef* vb,
         }
 
         plLayerInterface* lay = material->GetLayer(mRef->GetPassIndex(pass));
+        
+        /*
+         If the layer opacity is 0, don't draw it. This prevents it from contributing to the Z buffer.
+         This can happen with some models like the fire marbles in the neighborhood that have some models
+         for physics only, and then can block other rendering in the Z buffer.
+         DX pipeline does this in ILoopOverLayers.
+         */
+        if(lay->GetOpacity() <= 0) {
+            continue;
+        }
 
         ICalcLighting(mRef, lay, &span);
 


### PR DESCRIPTION
Found some things in the Metal debugger and bringing them back to the GL work. This should fix some rendering issues in the cavern neighborhood/Neighborhood.age.

I'm still working on the reflection co-ord fixes. That required several passes in Metal, so I'm still working on bundling those changes and re-applying them to GL.

Adding notes for the changes to the commits themselves. Let me know if you have any questions or concerns!