### PR TITLE
Opacity based culling fixes

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -778,7 +778,7 @@ uint32_t plGLMaterialShaderRef::IHandleMaterial(uint32_t layer, std::shared_ptr<
     // Handle High Alpha Threshold
     std::shared_ptr<plUniformNode> alphaThreshold = IFindVariable<plUniformNode>("uAlphaThreshold", "float");
 
-    std::shared_ptr<plConditionNode> alphaTest = COND(IS_LEQ(sb.fCurrAlpha, alphaThreshold));
+    std::shared_ptr<plConditionNode> alphaTest = COND(IS_LESS(sb.fCurrAlpha, alphaThreshold));
     alphaTest->PushOp(CONSTANT("discard"));
 
     // if (final.a < alphaThreshold) { discard; }


### PR DESCRIPTION
Sorry, I just added Eder Kemo to my testing circuit, and found issues with these changes there. The getOpacity check has been extended with more code from the DX branch, which should fix those issues. I can't find a way to fix the alpha threshold check change, so I'm removing it for now and back to researching solutions.

The GetOpacity based culling needed some more conditions, it was doing things like not rendering the fountain in Eder Kemo. That should be resolved now, and the fire marbles are still fixed.

The alpha threshold change caused unresolvable issues in Eder Kemo. Undoing for now. I'll have to figure out a better way to fix that hologram.