### PR TITLE
Better fix for Z-fighting with hologram

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp
@@ -927,7 +927,7 @@ void plGLPipeline::IRenderBufferSpan(const plIcicle& span, hsGDeviceRef* vb,
             if (s.fBlendFlags & hsGMatState::kBlendAlphaTestHigh) {
                 glUniform1f(mRef->uAlphaThreshold, 64.f/255.f);
             } else {
-                glUniform1f(mRef->uAlphaThreshold, 0.f);
+                glUniform1f(mRef->uAlphaThreshold, 0.00000000001f);
             }
         } else {
             glUniform1f(mRef->uAlphaThreshold, 0.f);


### PR DESCRIPTION
The DX version sets a really low threshold, but doesn’t actually set it to zero for when blending is enabled. Actual line from the DirectX is:
fD3DDevice->SetRenderState(D3DRS_ALPHAREF, 0x00000001);

This should fix things like the hologram in the neighborhood, and doesn’t break other things like blending in Eder Kemo.