### PR TITLE
Fix for directional lighting

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLMaterialShaderRef.cpp
@@ -131,7 +131,7 @@ void main() {
 
         if (uLampSources[i].position.w == 0.0) {
             // Directional Light with no attenuation
-            direction = normalize(uLampSources[i].direction);
+            direction = -uLampSources[i].direction;
             attenuation = 1.0;
         } else {
             // Omni Light in all directions


### PR DESCRIPTION
Hey, while working on the Metal branch I was getting weird issues in Eder Tsogal. I traced it back to the vertex lighting shader, which is based on the GL version. This pull request is back porting the fix to GL.

In the screenshots below, the lighting is coming from the top left of the scene, in front of the camera. Even though the sun is in front of the posts, the back of them is not shaded. Some other layers are completely unlit, like the metal pattern on the ground.

<img width="912" alt="Screen Shot 2022-01-01 at 11 10 28 PM" src="https://user-images.githubusercontent.com/476737/147868942-9cf55c8d-0b80-40ba-a524-de5ead332362.png">

The issue is that the directional light has a global normalized light vector relative to the entire scene, and isn't a position. The lighting algorithm is expecting a vector back to the light source for the computation. So to get a vector back to the light source, all that needs to be done is to negate the vector. (The vector is also already normalized.) Objects like the metal details can even be blacked out of the scene completely. A light source like a sun is going to be pointing in a negative z position. The metal detail layer is interpreting this as that the light is beneath it, and is not lighting.

With this change, the shader behaves more consistently with the scene and DirectX version. The back of the posts is now shadowing.

<img width="912" alt="Screen Shot 2022-01-01 at 11 11 34 PM" src="https://user-images.githubusercontent.com/476737/147868944-30213783-88e1-4965-932f-dc2c18d667ea.png">

I'm noticing improvements in other ages that use direction light as well. Eder Kemo also seems to have significant lighting improvements.