### PR TITLE
Adjust for compatibility with OpenGL 2.1 and GLSL 1.20

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plEGLDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plEGLDevice.cpp
@@ -77,7 +77,8 @@ bool plEGLDevice::Enumerate(hsG3DDeviceRecord& record)
             break;
 
         EGLint ctx_attrs[] = {
-            EGL_CONTEXT_MAJOR_VERSION, 3,
+            EGL_CONTEXT_MAJOR_VERSION, 2,
+            EGL_CONTEXT_MINOR_VERSION, 1,
             EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
             EGL_NONE
         };
@@ -99,7 +100,7 @@ bool plEGLDevice::Enumerate(hsG3DDeviceRecord& record)
         if (!eglMakeCurrent(display, surface, surface, context))
             break;
 
-        if (epoxy_gl_version() < 33)
+        if (epoxy_gl_version() < 21)
             break;
 
         record.SetG3DDeviceType(hsG3DDeviceSelector::kDevTypeOpenGL);
@@ -168,7 +169,8 @@ plEGLDevice* plEGLDevice::TryInit(hsWindowHndl window, hsDisplayHndl device, ST:
 
         /* Set up the GL context */
         EGLint ctx_attrs[] = {
-            EGL_CONTEXT_MAJOR_VERSION, 3,
+            EGL_CONTEXT_MAJOR_VERSION, 2,
+            EGL_CONTEXT_MINOR_VERSION, 1,
             EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
             EGL_NONE
         };

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLMaterialShaderRef.cpp
@@ -66,8 +66,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // From plGLDevice.cpp
 extern GLfloat* hsMatrix2GL(const hsMatrix44& src, GLfloat* dst);
 
-const char* VERTEX_SHADER_STRING = R"(#version 330
-precision lowp int;
+const char* VERTEX_SHADER_STRING = R"(#version 120
 
 struct lightSource {
     vec4 position;
@@ -84,10 +83,18 @@ struct lightSource {
 
 
 // Input Attributes
-layout(location =  0) in vec3 aVtxPosition;
-layout(location =  1) in vec3 aVtxNormal;
-layout(location =  2) in vec4 aVtxColor;
-layout(location =  3) in vec3 aVtxUVWSrc[8];
+attribute vec3 aVtxPosition;
+attribute vec3 aVtxNormal;
+attribute vec4 aVtxColor;
+//attribute vec3 aVtxUVWSrc[8];
+attribute vec3 aVtxUVWSrc0;
+attribute vec3 aVtxUVWSrc1;
+attribute vec3 aVtxUVWSrc2;
+attribute vec3 aVtxUVWSrc3;
+attribute vec3 aVtxUVWSrc4;
+attribute vec3 aVtxUVWSrc5;
+attribute vec3 aVtxUVWSrc6;
+attribute vec3 aVtxUVWSrc7;
 
 uniform mat4 uMatrixL2W;
 uniform mat4 uMatrixW2L;
@@ -109,10 +116,10 @@ uniform float uInvertVtxAlpha; // Effectively boolean, 0.0 or 1.0
 uniform lightSource uLampSources[8];
 
 // Varying outputs
-out vec4 vCamPosition;
-out vec4 vCamNormal;
-out vec4 vVtxColor;
-out vec3 vVtxUVWSrc[8];
+varying vec4 vCamPosition;
+varying vec4 vCamNormal;
+varying vec4 vVtxColor;
+varying vec3 vVtxUVWSrc[8];
 
 void main() {
     vec4 MAmbient = mix(aVtxColor.bgra, uAmbientCol, uAmbientSrc);
@@ -125,9 +132,16 @@ void main() {
 
     vec3 Ndirection = normalize(mat3(uMatrixW2L) * aVtxNormal);
 
-    for (int i = 0; i < 8; i++) {
-        vVtxUVWSrc[i] = aVtxUVWSrc[i];
+    vVtxUVWSrc[0] = aVtxUVWSrc0;
+    vVtxUVWSrc[1] = aVtxUVWSrc1;
+    vVtxUVWSrc[2] = aVtxUVWSrc2;
+    vVtxUVWSrc[3] = aVtxUVWSrc3;
+    vVtxUVWSrc[4] = aVtxUVWSrc4;
+    vVtxUVWSrc[5] = aVtxUVWSrc5;
+    vVtxUVWSrc[6] = aVtxUVWSrc6;
+    vVtxUVWSrc[7] = aVtxUVWSrc7;
 
+    for (int i = 0; i < 8; i++) {
         float attenuation;
         vec3 direction;
 
@@ -171,9 +185,7 @@ void main() {
 })";
 
 
-const char* FRAGMENT_SHADER_STRING = R"(#version 330
-precision mediump float;
-precision lowp int;
+const char* FRAGMENT_SHADER_STRING = R"(#version 120
 
 uniform mat4 uLayerMat0;
 
@@ -187,17 +199,17 @@ uniform sampler2D uTexture0;
 
 uniform float uAlphaThreshold;
 uniform int uFogExponential;
-uniform highp vec2 uFogValues;
+uniform vec2 uFogValues;
 uniform vec3 uFogColor;
 
 // Varying inputs
-in highp vec4 vCamPosition;
-in highp vec4 vCamNormal;
-in vec4 vVtxColor;
-in highp vec3 vVtxUVWSrc[8];
+varying vec4 vCamPosition;
+varying vec4 vCamNormal;
+varying vec4 vVtxColor;
+varying vec3 vVtxUVWSrc[8];
 
 // Rendered outputs
-out vec4 fragColor;
+//out vec4 fragColor;
 
 void main() {
     float baseAlpha;
@@ -208,27 +220,27 @@ void main() {
 
     baseAlpha = vVtxColor.a;
     coords0 = uLayerMat0 * vec4(vVtxUVWSrc[0], 1.0);
-    image0 = texture(uTexture0, coords0.xy);
+    image0 = texture2D(uTexture0, coords0.xy);
     currColor = image0.rgb;
     currAlpha = image0.a * baseAlpha;
     currColor = vVtxColor.rgb * currColor;
 
     if (currAlpha < uAlphaThreshold) { discard; };
 
-    highp float fogFactor = 1.0;
+    float fogFactor = 1.0;
     if (uFogExponential > 0) {
         fogFactor = exp(-pow(uFogValues.y * length(vCamPosition.xyz), uFogValues.x));
     } else {
         if (uFogValues.y > 0.0) {
-            highp float start = uFogValues.x;
-            highp float end = uFogValues.y;
+            float start = uFogValues.x;
+            float end = uFogValues.y;
             fogFactor = (end - length(vCamPosition.xyz)) / (end - start);
         }
     }
 
     currColor = mix(currColor, uFogColor, 1.0 - clamp(fogFactor, 0.0, 1.0));
 
-    fragColor = vec4(currColor, currAlpha);
+    gl_FragColor = vec4(currColor, currAlpha);
 })";
 
 plGLMaterialShaderRef::plGLMaterialShaderRef(hsGMaterial* mat, plGLPipeline* pipe)
@@ -416,6 +428,23 @@ void plGLMaterialShaderRef::ICompile()
 
     glAttachShader(fRef, fFragShaderRef);
     LOG_GL_ERROR_CHECK("Attach Fragment Shader failed")
+
+    glBindAttribLocation(fRef, 0, "aVtxPosition");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 0 failed");
+    glBindAttribLocation(fRef, 1, "aVtxNormal");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 1 failed");
+    glBindAttribLocation(fRef, 2, "aVtxColor");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 2 failed");
+    glBindAttribLocation(fRef, 3, "aVtxUVWSrc0");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 3 failed");
+    glBindAttribLocation(fRef, 4, "aVtxUVWSrc1");
+    glBindAttribLocation(fRef, 5, "aVtxUVWSrc2");
+    glBindAttribLocation(fRef, 6, "aVtxUVWSrc3");
+    glBindAttribLocation(fRef, 7, "aVtxUVWSrc4");
+    glBindAttribLocation(fRef, 8, "aVtxUVWSrc5");
+    glBindAttribLocation(fRef, 9, "aVtxUVWSrc6");
+    glBindAttribLocation(fRef, 10, "aVtxUVWSrc7");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 10 failed");
 }
 
 
@@ -423,6 +452,21 @@ void plGLMaterialShaderRef::ISetShaderVariableLocs()
 {
     glLinkProgram(fRef);
     LOG_GL_ERROR_CHECK("Program Link failed");
+
+    GLint isLinked = 0;
+    glGetProgramiv(fRef, GL_LINK_STATUS, &isLinked);
+    if (isLinked == GL_FALSE)
+    {
+        GLint maxLength = 0;
+        glGetProgramiv(fRef, GL_INFO_LOG_LENGTH, &maxLength);
+        
+        // The maxLength includes the NULL character
+        char* log = new char[maxLength];
+        glGetProgramInfoLog(fRef, maxLength, &maxLength, log);
+        
+        hsStatusMessage(log);
+        delete[] log;
+    }
 
     uPassNumber       = glGetUniformLocation(fRef, "uPassNumber");
     uAlphaThreshold   = glGetUniformLocation(fRef, "uAlphaThreshold");

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
@@ -1496,6 +1496,7 @@ void plGLPipeline::IDrawPlate(plPlate* plate)
         mRef->Link(&fMatRefList);
 
     glUseProgram(mRef->fRef);
+    LOG_GL_ERROR_CHECK(ST::format("Use Program with material \"{}\" (for plate) failed", material->GetKeyName()));
     fDevice.SetCurrentProgram(mRef->fRef);
 
     mRef->SetupTextureRefs();
@@ -1540,29 +1541,27 @@ struct plAVTexVert
     float fUv[2];
 };
 
-static const char* AVATAR_VERTEX_SHADER_STRING = R"(#version 430
+static const char* AVATAR_VERTEX_SHADER_STRING = R"(#version 120
 
-layout(location = 0) in vec2 aVtxPosition;
-layout(location = 1) in vec2 aVtxUV;
+attribute vec2 aVtxPosition;
+attribute vec2 aVtxUV;
 
-out vec2 vVtxUV;
+varying vec2 vVtxUV;
 
 void main() {
     vVtxUV = aVtxUV;
     gl_Position = vec4(aVtxPosition, 0.0, 1.0);
 })";
 
-static const char* AVATAR_FRAGMENT_SHADER_STRING = R"(#version 430
-precision mediump float;
+static const char* AVATAR_FRAGMENT_SHADER_STRING = R"(#version 120
 
-layout(location = 0) uniform sampler2D uTex;
-layout(location = 1) uniform vec4 uColor;
+uniform sampler2D uTex;
+uniform vec4 uColor;
 
-in highp vec2 vVtxUV;
-out vec4 fragColor;
+varying vec2 vVtxUV;
 
 void main() {
-    fragColor = texture(uTex, vVtxUV.xy) * uColor;
+    gl_FragColor = texture2D(uTex, vVtxUV.xy) * uColor;
 })";
 
 void plGLPipeline::IPreprocessAvatarTextures()
@@ -1589,6 +1588,23 @@ void plGLPipeline::IPreprocessAvatarTextures()
         glCompileShader(vshader);
         LOG_GL_ERROR_CHECK("Vertex Shader compile failed");
 
+        #ifdef HS_DEBUGGING
+        {
+            GLint compiled = 0;
+            glGetShaderiv(vshader, GL_COMPILE_STATUS, &compiled);
+            if (compiled == 0) {
+                GLint length = 0;
+                glGetShaderiv(vshader, GL_INFO_LOG_LENGTH, &length);
+                if (length) {
+                    char* log = new char[length];
+                    glGetShaderInfoLog(vshader, length, &length, log);
+                    hsStatusMessage(log);
+                    delete[] log;
+                }
+            }
+        }
+        #endif
+
         sVertShader = vshader;
     }
 
@@ -1597,6 +1613,23 @@ void plGLPipeline::IPreprocessAvatarTextures()
         glShaderSource(fshader, 1, &AVATAR_FRAGMENT_SHADER_STRING, nullptr);
         glCompileShader(fshader);
         LOG_GL_ERROR_CHECK("Vertex Shader compile failed");
+
+        #ifdef HS_DEBUGGING
+        {
+            GLint compiled = 0;
+            glGetShaderiv(fshader, GL_COMPILE_STATUS, &compiled);
+            if (compiled == 0) {
+                GLint length = 0;
+                glGetShaderiv(fshader, GL_INFO_LOG_LENGTH, &length);
+                if (length) {
+                    char* log = new char[length];
+                    glGetShaderInfoLog(fshader, length, &length, log);
+                    hsStatusMessage(log);
+                    delete[] log;
+                }
+            }
+        }
+        #endif
 
         sFragShader = fshader;
     }
@@ -1615,6 +1648,11 @@ void plGLPipeline::IPreprocessAvatarTextures()
 
         glAttachShader(program, sFragShader);
         LOG_GL_ERROR_CHECK("Attach Fragment Shader failed");
+
+        glBindAttribLocation(program, 0, "aVtxPosition");
+        LOG_GL_ERROR_CHECK("glBindAttribLocation 0 failed");
+        glBindAttribLocation(program, 1, "aVtxUV");
+        LOG_GL_ERROR_CHECK("glBindAttribLocation 1 failed");
 
         glLinkProgram(program);
         LOG_GL_ERROR_CHECK("Program Link failed");
@@ -1665,8 +1703,8 @@ void plGLPipeline::IPreprocessAvatarTextures()
         LOG_GL_ERROR_CHECK("Use Program failed");
         fDevice.SetCurrentProgram(sProgram);
 
-        glUniform1i(0, 0);
-        glUniform4f(1, 1.f, 1.f, 1.f, 1.f);
+        glUniform1i(glGetUniformLocation(sProgram, "uTex"), 0);
+        glUniform4f(glGetUniformLocation(sProgram, "uColor"), 1.f, 1.f, 1.f, 1.f);
         glDepthFunc(GL_LEQUAL);
         glDepthMask(GL_TRUE);
 

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLTextFont.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLTextFont.cpp
@@ -85,16 +85,16 @@ void plGLTextFont::ICreateTexture(uint16_t* data)
     }
 }
 
-static const char* TEXTFONT_VERTEX_SHADER_STRING = R"(#version 430
+static const char* TEXTFONT_VERTEX_SHADER_STRING = R"(#version 120
 
-layout(location = 0) in vec3 aVtxPosition;
-layout(location = 1) in vec4 aVtxColor;
-layout(location = 2) in highp vec3 aVtxUV;
+attribute vec3 aVtxPosition;
+attribute vec4 aVtxColor;
+attribute vec3 aVtxUV;
 
-layout(location = 1) uniform vec2 uPipeSize;
+uniform vec2 uPipeSize;
 
-out vec4 vVtxColor;
-out vec3 vVtxUV;
+varying vec4 vVtxColor;
+varying vec3 vVtxUV;
 
 void main() {
     mat4 projMatrix = mat4(1.0);
@@ -109,17 +109,15 @@ void main() {
     gl_Position = projMatrix * vec4(aVtxPosition, 1.0);
 })";
 
-static const char* TEXTFONT_FRAGMENT_SHADER_STRING = R"(#version 430
-precision mediump float;
+static const char* TEXTFONT_FRAGMENT_SHADER_STRING = R"(#version 120
 
-layout(location = 0) uniform sampler2D uTex;
+uniform sampler2D uTex;
 
-in vec4 vVtxColor;
-in highp vec3 vVtxUV;
-out vec4 fragColor;
+varying vec4 vVtxColor;
+varying vec3 vVtxUV;
 
 void main() {
-    fragColor = texture(uTex, vec2(vVtxUV.x, vVtxUV.y)) * vVtxColor;
+    gl_FragColor = texture2D(uTex, vec2(vVtxUV.x, vVtxUV.y)) * vVtxColor;
 })";
 
 void plGLTextFont::IInitStateBlocks()
@@ -129,10 +127,44 @@ void plGLTextFont::IInitStateBlocks()
     glCompileShader(vshader);
     LOG_GL_ERROR_CHECK("Vertex Shader compile failed");
 
+    #ifdef HS_DEBUGGING
+    {
+        GLint compiled = 0;
+        glGetShaderiv(vshader, GL_COMPILE_STATUS, &compiled);
+        if (compiled == 0) {
+            GLint length = 0;
+            glGetShaderiv(vshader, GL_INFO_LOG_LENGTH, &length);
+            if (length) {
+                char* log = new char[length];
+                glGetShaderInfoLog(vshader, length, &length, log);
+                hsStatusMessage(log);
+                delete[] log;
+            }
+        }
+    }
+    #endif
+
     GLuint fshader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(fshader, 1, &TEXTFONT_FRAGMENT_SHADER_STRING, nullptr);
     glCompileShader(fshader);
-    LOG_GL_ERROR_CHECK("Vertex Shader compile failed");
+    LOG_GL_ERROR_CHECK("Fragment Shader compile failed");
+
+    #ifdef HS_DEBUGGING
+    {
+        GLint compiled = 0;
+        glGetShaderiv(fshader, GL_COMPILE_STATUS, &compiled);
+        if (compiled == 0) {
+            GLint length = 0;
+            glGetShaderiv(fshader, GL_INFO_LOG_LENGTH, &length);
+            if (length) {
+                char* log = new char[length];
+                glGetShaderInfoLog(fshader, length, &length, log);
+                hsStatusMessage(log);
+                delete[] log;
+            }
+        }
+    }
+    #endif
 
     GLuint program = glCreateProgram();
     LOG_GL_ERROR_CHECK("Create Program failed");
@@ -147,6 +179,13 @@ void plGLTextFont::IInitStateBlocks()
 
     glAttachShader(program, fshader);
     LOG_GL_ERROR_CHECK("Attach Fragment Shader failed");
+
+    glBindAttribLocation(program, 0, "aVtxPosition");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 0 failed");
+    glBindAttribLocation(program, 1, "aVtxColor");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 1 failed");
+    glBindAttribLocation(program, 2, "aVtxUV");
+    LOG_GL_ERROR_CHECK("glBindAttribLocation 2 failed");
 
     glLinkProgram(program);
     LOG_GL_ERROR_CHECK("Program Link failed");
@@ -258,10 +297,10 @@ void plGLTextFont::SaveStates()
     glDepthRange(0.0, 1.0);
 
     glUseProgram(fShader);
-    LOG_GL_ERROR_CHECK("Use Program failed");
+    LOG_GL_ERROR_CHECK("Use Program failed for plGLTextFont");
 
-    glUniform1i(0, 0);
-    glUniform2f(1, float(fPipe->Width()), float(fPipe->Height()));
+    glUniform1i(glGetUniformLocation(fShader, "uTex"), 0);
+    glUniform2f(glGetUniformLocation(fShader, "uPipeSize"), float(fPipe->Width()), float(fPipe->Height()));
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glDepthFunc(GL_ALWAYS);
     glDepthMask(GL_TRUE);


### PR DESCRIPTION
This is what I needed to change to get it working on an original "Intel HD Graphics" integrated GPU, for which Mesa only supports OpenGL 2.1. With these changes, it runs and renders and Relto looks recognizable (but has various graphical oddities, but idk if those are "normal" for the current state of this branch).

Most of these changes are just replacing "modern" GLSL features with their older counterparts (`attribute`/`varying`/`gl_FragColor` instead of `in`/`out`, `texture2D` instead of `texture`, `glBindAttribLocation`/`glGetUniformLocation` in code instead of `layout(location = ...)` in GLSL). I removed the `lowp`/`mediump`/`highp` keywords, because apparently those only existed in GLSL ES and not regular GLSL at the time. The most complex change was replacing an array `attribute` with single scalars, because apparently GLSL 2.1 doesn't support array `attribute`s. I also added missing error checks/logging in various places.

I don't know enough about OpenGL to say whether these changes could cause trouble on modern GPUs. For example, I don't know how important the `lowp`/`mediump`/`highp` keywords are. One could conditionally load different variants of the shaders depending on OpenGL version, but that adds complexity.